### PR TITLE
Update pr-ci.yml

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,6 +3,15 @@ name: PR CI
 on:
   pull_request:
     branches: [ main, master ]
+  push:
+    branches: [ main ]               # run CI when pushing to main
+    paths:                           # optional: only when relevant files change
+      - '**/*.py'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - 'templates/**'
+      - 'tests/**'
+      - '.github/workflows/**'
 
 jobs:
   secrets-scan:


### PR DESCRIPTION
This change went straight to #main (commit eb1f0be), not through a branch/PR. That’s why you don’t see a PR. It’s fine, but you skipped PR checks and reviews for this one. What I’d do now:
- Keep the commit as-is (no need to undo it).
- Make the workflow also run on pushes to main, so CI runs even when you tweak YAML directly on main.
- Replace the top of .github/workflows/pr-ci.yml with the trigger block.