### PR TITLE
chore(docker): add .dockerignore to slim build context and exclude local/test artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Python junk
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+.venv/
+.env
+.env.*
+
+# Tests & tooling artifacts
+tests/
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+.cache/
+.ipynb_checkpoints/
+
+# VCS / CI / docs that aren't needed at runtime
+.git/
+.gitattributes
+.gitignore
+.github/
+*.md
+
+# Local data & heavy sample files (don’t ship to container)
+uploads/*
+!uploads/.gitkeep
+*.csv
+*.xlsx
+*.zip
+*.pdf
+
+# OS/editor noise
+.DS_Store
+Thumbs.db
+.vscode/


### PR DESCRIPTION
Adds a .dockerignore to keep the Docker build context small and prevent accidental inclusion of local files.

What’s ignored (key groups)
- Python junk: __pycache__/, *.py[cod], *.pyo, *.pyd, *.egg-info/, .venv/, .env, .env.*
- Tests & tooling: tests/, .pytest_cache/, .coverage, htmlcov/, .mypy_cache/, .cache/, .ipynb_checkpoints/
- VCS/CI/docs: .git/, .github/, .gitattributes, .gitignore, *.md
- Local data & heavy samples: uploads/* (keeps uploads/.gitkeep), *.csv, *.xlsx, *.zip, *.pdf
- OS/editor noise: .DS_Store, Thumbs.db, .vscode/

Why
- Speeds up `docker build` by sending fewer files to the daemon.
- Reduces image size and lowers risk of shipping secrets or large local artifacts.
- No runtime/app behavior change. Render (Python service) is unaffected; this helps our CI Docker build.

Notes
- If we ever decide to *bundle* sample files inside the image, remove or narrow the `*.csv|*.xlsx|*.zip|*.pdf` lines.
- `.env` remains excluded from the image.

Verification
- CI will build and smoke-test the image (PR CI / ci).
- Confirmed `uploads/.gitkeep` is preserved so the folder exists.

Risk
- Very low; only affects Docker build context. No code paths changed.

BREAKING CHANGES: none
