### PR TITLE
docs: fix project structure formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Troubleshooting
 Project Structure
 =================
 
+```text
 Capstone-FinGPT/
 ├─ app.py
 ├─ app_validators.py


### PR DESCRIPTION
- Reformatted the Project Structure section using a fenced code block so the tree renders correctly.
- Ensures each file appears on its own line and matches the actual repository layout.
- Improves readability and prevents GitHub from collapsing the structure into a single wrapped line.